### PR TITLE
refactor: Rename solver functions for clarity, encapsulate Pardiso solver in a module, and add ill-conditioned projection and improved eigenvector handling to the dense solver.

### DIFF
--- a/dptb/postprocess/pardiso/solvers/dense_solver.jl
+++ b/dptb/postprocess/pardiso/solvers/dense_solver.jl
@@ -10,12 +10,12 @@ module DenseSolver
 using LinearAlgebra
 using SparseArrays
 
-export solve_eigen_k
+export solve_eigen_k_dense
 
 const default_dtype = Complex{Float64}
 
 """
-    solve_eigen_k(H_k, S_k, fermi_level, num_band, args...)
+    solve_eigen_k_dense(H_k, S_k, fermi_level, num_band, max_iter, out_wfc, ill_project, ill_threshold)
 
 Solve eigenvalue problem using dense diagonalization (ZHEGV).
 
@@ -30,7 +30,7 @@ Solve eigenvalue problem using dense diagonalization (ZHEGV).
 - `evecs`: Eigenvectors (if requested, currently empty for band calc)
 - `residual`: 0.0
 """
-function solve_eigen_k(H_k, S_k, fermi_level, num_band, args...)
+function solve_eigen_k_dense(H_k, S_k, fermi_level, num_band, max_iter, out_wfc, ill_project, ill_threshold)
     # Convert to dense matrices
     H_dense = Matrix(H_k)
     S_dense = Matrix(S_k)
@@ -39,44 +39,85 @@ function solve_eigen_k(H_k, S_k, fermi_level, num_band, args...)
     H_dense = Hermitian(H_dense)
     S_dense = Hermitian(S_dense)
     
-    # Solve full eigenvalue problem
-    # eigen returns sorted values by default
-    full_vals, full_vecs = eigen(H_dense, S_dense)
+    if ill_project
+        # 1. Diagonalize S first to find good subspace
+        egval_S, egvec_S = eigen(S_dense)
+        
+        # 2. Filter good states
+        project_index = abs.(egval_S) .> ill_threshold
+        n_good = sum(project_index)
+        
+        if n_good < size(H_k, 1)
+            # @warn "Ill-conditioned eigenvalues detected, projecting out $(size(H_k, 1) - n_good) states"
+            egvec_S_good = egvec_S[:, project_index]
+            
+            # 3. Project H and S to the good subspace
+            # H_k_proj = V' * H * V
+            H_k_proj = egvec_S_good' * H_dense * egvec_S_good
+            S_k_proj = egvec_S_good' * S_dense * egvec_S_good
+            
+            # 4. Solve the projected (smaller) problem
+            # Using Hermitian wrapper to ensure real eigenvalues
+            full_vals_proj, full_vecs_proj = eigen(Hermitian(H_k_proj), Hermitian(S_k_proj))
+            
+            # 5. Reconstruct full eigenvectors if needed
+            # The "bad" states are set to high energy (fermi + 1e4)
+            full_vals = vcat(full_vals_proj, fill(1e4 + fermi_level, size(H_k, 1) - n_good))
+            
+            if out_wfc
+                # Recover eigenvectors in original basis: V_full = V_good * V_proj
+                egvec_good = egvec_S_good * full_vecs_proj
+                # Pad with zeros for projected-out states
+                full_vecs = hcat(egvec_good, zeros(default_dtype, size(H_k, 1), size(H_k, 1) - n_good))
+            else
+                 # Placeholder if not needed
+                 full_vecs = zeros(default_dtype, size(H_k, 1), 0)
+            end
+        else
+            # No projection needed
+            full_vals, full_vecs = eigen(H_dense, S_dense)
+        end
+    else
+        full_vals, full_vecs = eigen(H_dense, S_dense)
+    end
     
     # Select bands closest to Fermi level
-    # 1. Calculate distance to E_fermi
     diff = abs.(full_vals .- fermi_level)
     
-    # 2. Get indices of 'num_band' closest eigenvalues
+    # Get indices of 'num_band' closest eigenvalues
     perm = sortperm(diff)
     closest_indices = perm[1:min(length(perm), num_band)]
     
-    # 3. Sort indices to keep bands ordered by energy (not by distance)
-    # Actually, we usually want the lowest N bands or N bands around Fermi?
-    # In band structure, we want the N bands that are "in the window".
-    # Typically, we just return the sorted eigenvalues that fall in the window.
-    
-    # Logic from legacy script:
-    # "Iterate indices to find min/max and take contiguous block"
-    # Here let's strictly take the N closest for now to match legacy behavior
-    
-    # But wait, band structure needs continuity k->k+1.
-    # Selecting "closest N" at each k might cause band switching if N is small.
-    # Legacy script did: Calculate full, then select range indices [start:end] based on first k-point
-    # For now, let's just return the subset indices sorted by energy
-    
+    # Sort indices to keep bands ordered by energy
     sort!(closest_indices)
     
-    # Check if we have enough
-    if length(closest_indices) < num_band
-        # Pad with very large values if not enough states (unlikely for dense)
-        # But here we just return what we have
-    end
-    
+    # Extract eigenvalues
     evals = full_vals[closest_indices]
     
-    # We don't need eigenvectors for simple band structure plot
-    evecs = zeros(default_dtype, size(H_k, 1), 0)
+    # Check if we have enough bands and pad if necessary
+    if length(evals) < num_band
+        n_pad = num_band - length(evals)
+        pad_vals = fill(1e4 + fermi_level, n_pad)
+        evals = vcat(evals, pad_vals)
+    end
+    
+    # Handle eigenvectors output
+    if out_wfc
+        # Extract corresponding eigenvectors
+        # Note: full_vecs might be empty if we skipped calculation in projection branch (though currently we calc or placeholder)
+        if size(full_vecs, 2) > 0
+             evecs = full_vecs[:, closest_indices]
+             
+             # Pad evecs if necessary
+             if size(evecs, 2) < num_band
+                 evecs = hcat(evecs, zeros(default_dtype, size(H_k, 1), num_band - size(evecs, 2)))
+             end
+        else
+             evecs = zeros(default_dtype, size(H_k, 1), 0)
+        end
+    else
+        evecs = zeros(default_dtype, size(H_k, 1), 0)
+    end
     
     return evals, evecs, 0.0
 end

--- a/dptb/postprocess/pardiso/solvers/pardiso_solver.jl
+++ b/dptb/postprocess/pardiso/solvers/pardiso_solver.jl
@@ -4,6 +4,7 @@ Pardiso-based eigenvalue solver for large-scale tight-binding systems.
 This module provides efficient eigenvalue solvers using Intel MKL Pardiso
 with shift-invert technique for better convergence.
 """
+module PardisoSolver
 
 using Pardiso
 using Arpack
@@ -52,11 +53,11 @@ function make_shift_invert_map(H::AbstractMatrix, S::AbstractMatrix)
 end
 
 """
-    solve_eigen_k(H_k, S_k, fermi_level, num_band, max_iter, out_wfc, ill_project, ill_threshold)
+    solve_eigen_k_pardiso(H_k, S_k, fermi_level, num_band, max_iter, out_wfc, ill_project, ill_threshold)
 
 Solve generalized eigenvalue problem H|ψ⟩ = E S|ψ⟩ at a single k-point using Pardiso shift-invert.
 """
-function solve_eigen_k(H_k, S_k, fermi_level, num_band, max_iter, out_wfc, ill_project, ill_threshold)
+function solve_eigen_k_pardiso(H_k, S_k, fermi_level, num_band, max_iter, out_wfc, ill_project, ill_threshold)
     if ill_project
         lm, ps = make_shift_invert_map(Hermitian(H_k) - fermi_level * Hermitian(S_k), Hermitian(S_k))
 
@@ -124,4 +125,6 @@ function solve_eigen_k(H_k, S_k, fermi_level, num_band, max_iter, out_wfc, ill_p
     end
 end
 
-export make_shift_invert_map, solve_eigen_k
+export make_shift_invert_map, solve_eigen_k_pardiso
+
+end # module


### PR DESCRIPTION
*   Renamed `solve_eigen_k` to `solve_eigen_k_pardiso` (in `PardisoSolver`) and `solve_eigen_k_dense` (in `DenseSolver`) to explicitly distinguish between implementations and avoid Julia's global function shadowing issues.
*   Updated [main.jl] to import and dispatch these functions explicitly.
*   Ported the "Ill-conditioned Projection" logic  to `dense_solver`.